### PR TITLE
build: Update releaser config

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -1,18 +1,20 @@
+version: 2
+
 repo:
   public: roku-client-sdk
   private: roku-client-sdk-private
+
+jobs:
+  - docker:
+      image: circleci/node
 
 branches:
   - name: main
   - name: 1.x
 
-circleci:
-  linux:
-    image: circleci/node
-
 documentation:
   title: LaunchDarkly Client-Side SDK for Roku
-  githubPages: true
+  gitHubPages: false
 
 sdk:
   displayName: "Roku (client-side)"

--- a/.ldrelease/publish.sh
+++ b/.ldrelease/publish.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-mkdir -p artifacts
-
-cp package.zip artifacts/
+cp package.zip "$LD_RELEASE_ARTIFACTS_DIR"

--- a/.ldrelease/update-version.sh
+++ b/.ldrelease/update-version.sh
@@ -3,7 +3,5 @@
 set -e
 
 TARGET_FILE=rawsrc/LaunchDarklyVersion.brs
-TEMP_FILE=${TARGET_FILE}.tmp
 
-sed "s/    return \".*\"/    return \"${LD_RELEASE_VERSION}\"/" "${TARGET_FILE}" > "${TEMP_FILE}"
-mv "${TEMP_FILE}" "${TARGET_FILE}"
+sed -i "s/    return \".*\"/    return \"${LD_RELEASE_VERSION}\"/" "${TARGET_FILE}"


### PR DESCRIPTION
Version 1 of the releaser config is very dated and not well supported. This update brings us inline with more modern releaser configurations.