### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Repository Maintainers
+* @launchdarkly/team-sdk-brightscript


### PR DESCRIPTION
Adds code-owners file with @launchdarkly/team-sdk-brightscript.