### PR TITLE
ci: Fix release artifact upload

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -6,11 +6,16 @@ inputs:
     description: 'The name of the release tag to publish against'
     type: string
     required: true
+  token:
+    description: 'The token to use for uploading the release artifact'
+    type: string
+    required: true
 
 runs:
   using: composite
   steps:
     - name: Upload Release Artifact
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+      shell: bash
       run: gh release upload ${{ inputs.tag_name }} package.zip --clobber

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -26,4 +26,5 @@ jobs:
       - uses: ./.github/actions/publish
         if: ${{ !inputs.dry_run }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,4 +32,5 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/actions/publish
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
The last publication step of the release process failed last time because:

1. We were missing the required `shell` designation in the step, and
2. Secrets aren't directly accessible from within a GH action.

You can see the [previously failed build here](https://github.com/launchdarkly/roku-client-sdk/actions/runs/8284848664/job/22671297652) if you are interested.