### PR TITLE
fix: Fix evaluation race between status and flag fields

### DIFF
--- a/rawsrc/LaunchDarklyClient.brs
+++ b/rawsrc/LaunchDarklyClient.brs
@@ -1,7 +1,7 @@
 function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Object) as Object
     return {
         variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic) as Object
-            if m.status.getStatus() <> m.status.map.initialized then
+            if m.status.getStatus() <> m.status.map.initialized and not m.private.store.initialized() then
                 launchDarklyLocalReason = {}
                 launchDarklyLocalReason["kind"] = "ERROR"
                 launchDarklyLocalReason["errorKind"] = "CLIENT_NOT_READY"

--- a/rawsrc/LaunchDarklySG.brs
+++ b/rawsrc/LaunchDarklySG.brs
@@ -16,6 +16,7 @@ function LaunchDarklySG(launchDarklyParamClientNode as Dynamic) as Object
             logger: launchDarklyLocalLogger,
             offline: launchDarklyParamClientNode.config.private.offline,
             storeNode: launchDarklyParamClientNode.config.private.storeBackendNode,
+            store: LaunchDarklyStoreSG(launchDarklyParamClientNode.config.private.storeBackendNode),
 
             isOffline: function() as Boolean
                 return m.offline

--- a/rawsrc/LaunchDarklyStore.brs
+++ b/rawsrc/LaunchDarklyStore.brs
@@ -4,6 +4,21 @@ function LaunchDarklyStoreSG(launchDarklyParamNode) as Object
             node: launchDarklyParamNode
         },
 
+        initialized: function() as Boolean
+          ' WARN: If the environment has 0 flags, this store will report that
+          ' it is not initialized even though it technically is.
+          '
+          ' Ideally we would have a way to distinguish between those two states
+          ' but doing so requires extending the surface interface of the
+          ' SceneGraph by adding another field or changing the format of the
+          ' existing data.
+          '
+          ' Long term it would be good to change the payloads in the flags node
+          ' to store the initialization status along with the flag values
+          ' instead of treating them separately.
+          return m.private.node.flags.Count() > 0
+        end function,
+
         get: function(launchDarklyParamKey as String) as Object
             return m.private.node.flags.lookup(launchDarklyParamKey)
         end function,
@@ -71,8 +86,13 @@ function LaunchDarklyStore(launchDarklyParamBackend=invalid as Object) as Object
         private: {
             cache: {},
             backend: launchDarklyParamBackend,
-            bypassReadCache: false
+            bypassReadCache: false,
+            initialized: false
         },
+
+        initialized: function() as Boolean
+          return m.private.initialized
+        end function,
 
         get: function(launchDarklyParamKey as String) as Object
             launchDarklyLocalFlag = invalid
@@ -131,6 +151,7 @@ function LaunchDarklyStore(launchDarklyParamBackend=invalid as Object) as Object
 
         putAll: function(launchDarklyParamFlags as Object) as Void
             m.private.cache = launchDarklyParamFlags
+            m.private.initialized = true
 
             if m.private.backend <> invalid then
                 m.private.backend.putAll(launchDarklyParamFlags)


### PR DESCRIPTION
When the SDK is first initializing, the flag field is set before the status field on the LaunchDarkly node. As a result, listeners on the flag field would be executed before the status field is changed.

If a flag change listener tries to evaluate a flag the first time a change is triggered, the default value will be returned along with an error that the client isn't ready since the SDK doesn't think it is initialized.

To fix this, evaluation is allowed to continue if the SDK is initialized or if the store has flag data present. This is inline with other mobile SDKs.