### PR TITLE
ci: use draft releases to support immutable GitHub releases

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -10,6 +10,11 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build-publish:
@@ -28,3 +33,19 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ inputs.tag_name }}
+
+  publish-release:
+    needs: ['build-publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -29,14 +29,14 @@ jobs:
       - uses: ./.github/actions/ci
 
       - uses: ./.github/actions/publish
-        if: ${{ !inputs.dry_run }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ inputs.tag_name }}
 
   publish-release:
     needs: ['build-publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    if: ${{ format('{0}', inputs.dry_run) == 'false' && format('{0}', inputs.publish_release) == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,7 +62,6 @@ jobs:
       - uses: ./.github/actions/ci
 
       - name: Upload Release Artifact
-        if: ${{ needs.release-please.outputs.release_created == 'true' }}
         uses: ./.github/actions/publish
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,27 +6,67 @@ on:
       - main
 
 jobs:
-  release-package:
+  release-please:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Needed if using OIDC to get release secrets.
-      contents: write # Contents and pull-requests are for release-please to make releases.
+      contents: write
       pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
 
+  release-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
-          fetch-depth: 0 # Full history is required for proper changelog generation
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
 
       - uses: ./.github/actions/ci
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Upload Release Artifact
-        if: ${{ steps.release.outputs.release_created == 'true' }}
+        if: ${{ needs.release-please.outputs.release_created == 'true' }}
         uses: ./.github/actions/publish
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ steps.release.outputs.tag_name }}
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'release-package']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,6 @@ jobs:
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       # Create any releases first, then create tags, and then optionally create any new PRs.
@@ -50,7 +49,7 @@ jobs:
 
   release-package:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -71,7 +70,7 @@ jobs:
 
   publish-release:
     needs: ['release-please', 'release-package']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,7 +71,7 @@ jobs:
 
   publish-release:
     needs: ['release-please', 'release-package']
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,37 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
+        with:
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          skip-github-release: true
 
   release-package:
     needs: release-please
@@ -30,21 +59,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
 
       - uses: ./.github/actions/ci
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "versioning": "default",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
+      "draft": true,
       "extra-files": [
         "rawsrc/LaunchDarklyClient.brs"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "rawsrc/LaunchDarklyClient.brs"
       ]


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only changes with no functional code modifications.

**Related issues**

Supports the org-wide migration to immutable GitHub releases, which prevents modifying a release after it has been published.

**Describe the solution you've provided**

LaunchDarkly has enabled immutable GitHub releases. Once a release is published, it cannot be modified — which breaks workflows that upload artifacts *after* release-please creates and publishes the release. This repo uploads `package.zip` as a release artifact, so it needs the draft release pattern.

This PR makes the following changes:

1. **Draft releases & force-tag-creation** (`release-please-config.json`): Added `"draft": true` so release-please creates draft (unpublished) releases, allowing artifacts to be uploaded before the release goes live. Also added `"force-tag-creation": true` (not yet supported by release-please, but included for forward compatibility once support lands).

2. **Split release-please pattern** (`release-please.yml`): The `release-please` job now runs release-please in two passes to ensure tags exist before release-please checks for them:
   - **First pass** (`skip-github-pull-request: true`): Only creates releases (no PRs). If a release is created, the job checks out the repo and creates the Git tag manually (idempotent — skips if tag already exists).
   - **Second pass** (`skip-github-release: true`, conditional): Only runs if no release was created in the first pass, and only creates/updates PRs. This prevents release-please from creating duplicate release PRs because it depends on the tag existing when determining if a release PR is needed.

3. **Publish-release job** (`release-please.yml`): A new `publish-release` job runs after `release-package` completes and un-drafts the release via `gh release edit --draft=false`.

4. **Manual publish workflow** (`manual-publish.yml`): Added a `publish_release` boolean input (default: `true`) and a `publish-release` job that un-drafts the release after `build-publish` completes. Setting `publish_release` to `false` allows operators to keep the release in draft state after artifact uploads.

5. **Pinned action version**: `release-please-action` pinned to `@16a9c90856f42705d54a6fda1823352bdc62cf38` (v4.4.0).

The original single-job workflow was split into three jobs (`release-please` → `release-package` → `publish-release`). This follows the canonical pattern from [`launchdarkly/ld-relay` commit 1581de9](https://github.com/launchdarkly/ld-relay/commit/1581de978a391ad07d05b909ca9438fa3ad98556).

**Key review points:**

- The original workflow used `releases_created` (plural) to gate checkout/CI and `release_created` (singular) to gate the upload step. This distinction is preserved: `releases_created` gates the `release-package` job, while `release_created` gates the upload step and `publish-release` job.
- Tag names are passed via `env:` variables in `run:` blocks to avoid script injection. `${{ github.repository }}` is used only in safe contexts (GitHub-controlled, not user input).
- The `publish-release` job's `needs` array in `release-please.yml` includes both `release-please` and `release-package`, ensuring the release is only un-drafted after all artifacts are uploaded.
- In `manual-publish.yml`, the `publish-release` job is gated on `!inputs.dry_run && inputs.publish_release`. If `dry_run` is true or `publish_release` is false, the release stays in draft.
- [ ] Verify the second release-please pass condition (`release_created != 'true'`) correctly covers the case where release-please has pending version bumps but no release was created this run.
- [ ] Confirm the `./.github/actions/publish` composite action uses `gh release upload` with `--clobber` or otherwise handles the draft release state correctly.
- [ ] `force-tag-creation` has no effect today but will activate automatically once a supporting release-please version is available, at which point the manual tag creation step can be removed.

**Describe alternatives you've considered**

None — this follows the canonical pattern established in `launchdarkly/ld-relay`.

**Additional context**

- The `./.github/actions/publish` composite action uses `gh release upload ${{ inputs.tag_name }}` with inline interpolation rather than an env var — this is outside the scope of this PR but worth noting for a future hardening pass.
- No SLSA/attestation changes were needed as this repo does not use SLSA provenance.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation workflow (release/tag creation and publishing order), which could affect release publishing/tagging if conditions or GH CLI steps misfire. No runtime code changes, but failures would block or incorrectly publish releases.
> 
> **Overview**
> Moves the release pipeline to a **draft-release** pattern so release artifacts can be uploaded before a GitHub release is published/immutable.
> 
> `release-please` is split into a two-pass flow that creates draft releases first, then ensures the corresponding git tag exists (creating it if needed), and only creates/updates release PRs when no release was created. Packaging/artifact upload is moved into a dependent `release-package` job, followed by a new `publish-release` job that un-drafts the release via `gh release edit --draft=false`.
> 
> Manual publishing gains a `publish_release` input and a follow-on job to optionally un-draft the release after uploading artifacts, and `release-please-config.json` now enables `draft: true` (plus `force-tag-creation: true` for forward compatibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967d0fe6f6614c7b8f3e92d6f8178ec262fcb43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->