### PR TITLE
fix: add defensive cycle guard to prerequisite evaluation

### DIFF
--- a/rawsrc/LaunchDarklyClient.brs
+++ b/rawsrc/LaunchDarklyClient.brs
@@ -1,6 +1,6 @@
 function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Object) as Object
     return {
-        variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic, launchDarklyParamVisited=invalid as Dynamic) as Object
+        variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic, launchDarklyParamVisited=invalid as Object) as Object
             if m.status.getStatus() <> m.status.map.initialized and not m.private.store.initialized() then
                 launchDarklyLocalReason = {}
                 launchDarklyLocalReason["kind"] = "ERROR"

--- a/rawsrc/LaunchDarklyClient.brs
+++ b/rawsrc/LaunchDarklyClient.brs
@@ -1,7 +1,7 @@
-function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Object) as Object
+function LaunchDarklyClientSharedPrivateFunctions() as Object
     return {
-        variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic, launchDarklyParamVisited=invalid as Object) as Object
-            if m.status.getStatus() <> m.status.map.initialized and not m.private.store.initialized() then
+        variationDetail: function(launchDarklyParamStatus as Object, launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic, launchDarklyParamVisited=invalid as Object) as Object
+            if launchDarklyParamStatus.getStatus() <> launchDarklyParamStatus.map.initialized and not m.store.initialized() then
                 launchDarklyLocalReason = {}
                 launchDarklyLocalReason["kind"] = "ERROR"
                 launchDarklyLocalReason["errorKind"] = "CLIENT_NOT_READY"
@@ -12,10 +12,10 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
 
                 return launchDarklyLocalDetails
             else
-                launchDarklyLocalFlag = m.private.lookupFlag(launchDarklyParamFlagKey)
+                launchDarklyLocalFlag = m.lookupFlag(launchDarklyParamFlagKey)
 
                 if launchDarklyLocalFlag = invalid or launchDarklyLocalFlag.deleted = true then
-                    m.private.logger.error("missing flag")
+                    m.logger.error("missing flag")
 
                     launchDarklyLocalReason = {}
                     launchDarklyLocalReason["kind"] = "ERROR"
@@ -33,7 +33,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                         launchDarklyLocalState.reason = LaunchDarklyUtility().deepCopy(launchDarklyLocalReason)
                     end if
 
-                    m.private.handleEventsForEval(launchDarklyLocalState)
+                    m.handleEventsForEval(launchDarklyLocalState)
 
                     launchDarklyLocalDetails = {}
                     launchDarklyLocalDetails["result"] = launchDarklyParamFallback
@@ -49,7 +49,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                         if launchDarklyParamStrong(launchDarklyLocalFlag.value) = true then
                             launchDarklyLocalValue = launchDarklyLocalFlag.value
                         else
-                            m.private.logger.error("eval type mismatch")
+                            m.logger.error("eval type mismatch")
 
                             launchDarklyLocalValue = launchDarklyParamFallback
 
@@ -80,7 +80,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                         launchDarklyLocalState.reason = LaunchDarklyUtility().deepCopy(launchDarklyLocalReason)
                     end if
 
-                    m.private.handleEventsForEval(launchDarklyLocalState)
+                    m.handleEventsForEval(launchDarklyLocalState)
 
                     if launchDarklyLocalFlag.prerequisites <> invalid AND launchDarklyLocalFlag.prerequisites.count() > 0 then
                       ' Recurse on prerequisites to emit their evaluation events.
@@ -95,7 +95,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                         if launchDarklyLocalAncestors.doesExist(prereqKey) then
                           ' Cyclic edge: skip descent.
                         else
-                          m.variationDetail(prereqKey, invalid, launchDarklyParamEmbedReason, launchDarklyParamStrong, launchDarklyLocalAncestors)
+                          m.variationDetail(launchDarklyParamStatus, prereqKey, invalid, launchDarklyParamEmbedReason, launchDarklyParamStrong, launchDarklyLocalAncestors)
                         end if
                       End For
                       launchDarklyLocalAncestors.delete(launchDarklyParamFlagKey)
@@ -112,6 +112,14 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                     return launchDarklyLocalDetails
                 end if
             end if
+        end function
+    }
+end function
+
+function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Object) as Object
+    return {
+        variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic) as Object
+            return m.private.variationDetail(m.status, launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, launchDarklyParamStrong)
         end function,
 
         intVariationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Integer, launchDarklyParamEmbedReason=true as Dynamic) as Object
@@ -121,19 +129,19 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
         end function,
 
         boolVariationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Boolean, launchDarklyParamEmbedReason=true as Dynamic) as Object
-            return m.variationDetail(launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
+            return m.private.variationDetail(m.status, launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
                 return getInterface(launchDarklyParamValue, "ifBoolean") <> invalid
             end function)
         end function,
 
         stringVariationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as String, launchDarklyParamEmbedReason=true as Dynamic) as Object
-            return m.variationDetail(launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
+            return m.private.variationDetail(m.status, launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
                 return getInterface(launchDarklyParamValue, "ifString") <> invalid
             end function)
         end function,
 
         jsonVariationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Object, launchDarklyParamEmbedReason=true as Dynamic) as Object
-            return m.variationDetail(launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
+            return m.private.variationDetail(m.status, launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
                 if getInterface(launchDarklyParamValue, "ifAssociativeArray") <> invalid then
                     return true
                 else if getInterface(launchDarklyParamValue, "ifArray") <> invalid then
@@ -145,7 +153,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
         end function,
 
         doubleVariationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Double, launchDarklyParamEmbedReason=true as Dynamic) as Object
-            launchDarklyLocalResult = m.variationDetail(launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
+            launchDarklyLocalResult = m.private.variationDetail(m.status, launchDarklyParamFlagKey, launchDarklyParamFallback, launchDarklyParamEmbedReason, function(launchDarklyParamValue as Dynamic) as Boolean
                 if getInterface(launchDarklyParamValue, "ifFloat") <> invalid then
                     return true
                 else if getInterface(launchDarklyParamValue, "ifDouble") <> invalid then
@@ -162,7 +170,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
         end function,
 
         variation: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamStrong=invalid as Dynamic) as Dynamic
-            return m.variationDetail(launchDarklyParamFlagKey, launchDarklyParamFallback, false, launchDarklyParamStrong).result
+            return m.private.variationDetail(m.status, launchDarklyParamFlagKey, launchDarklyParamFallback, false, launchDarklyParamStrong).result
         end function,
 
         intVariation: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Integer) as Integer
@@ -505,6 +513,7 @@ function LaunchDarklyClient(launchDarklyParamConfig as Object, context as Object
         end function
     }
 
+    launchDarklyLocalThis.private.append(LaunchDarklyClientSharedPrivateFunctions())
     launchDarklyLocalThis.append(LaunchDarklyClientSharedFunctions(launchDarklyParamConfig.private.sceneGraphNode))
 
     launchDarklyLocalThis.private.streamClient = LaunchDarklyStreamClient(launchDarklyParamConfig, launchDarklyLocalStore, launchDarklyParamMessagePort, context, launchDarklyLocalThis.status)

--- a/rawsrc/LaunchDarklyClient.brs
+++ b/rawsrc/LaunchDarklyClient.brs
@@ -1,6 +1,6 @@
 function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Object) as Object
     return {
-        variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic) as Object
+        variationDetail: function(launchDarklyParamFlagKey as String, launchDarklyParamFallback as Dynamic, launchDarklyParamEmbedReason=true as Boolean, launchDarklyParamStrong=invalid as Dynamic, launchDarklyParamVisited=invalid as Dynamic) as Object
             if m.status.getStatus() <> m.status.map.initialized and not m.private.store.initialized() then
                 launchDarklyLocalReason = {}
                 launchDarklyLocalReason["kind"] = "ERROR"
@@ -82,10 +82,31 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
 
                     m.private.handleEventsForEval(launchDarklyLocalState)
 
-                    if launchDarklyLocalFlag.prerequisites <> invalid then
+                    if launchDarklyLocalFlag.prerequisites <> invalid AND launchDarklyLocalFlag.prerequisites.count() > 0 then
+                      ' Recurse on prerequisites to emulate prereq evaluations occurring with
+                      ' desirable side effects such as events for prereqs.
+                      '
+                      ' launchDarklyParamVisited tracks the chain of prerequisite dependencies
+                      ' from the top-level evaluation to (but not including) the current flag.
+                      ' It is allocated lazily: variation calls on prereq-less flags allocate
+                      ' no associative array. Once created it is shared for the rest of the
+                      ' walk via add-before-recurse / delete-after-recurse. A prerequisite key
+                      ' already in the map closes a cycle; descent is skipped and the loop
+                      ' continues with the remaining prerequisites at the current level.
+                      launchDarklyLocalAncestors = launchDarklyParamVisited
+                      if launchDarklyLocalAncestors = invalid then
+                          launchDarklyLocalAncestors = {}
+                      end if
+                      launchDarklyLocalAncestors[launchDarklyParamFlagKey] = true
                       For Each prereqKey in launchDarklyLocalFlag.prerequisites
-                        m.variationDetail(prereqKey, invalid, launchDarklyParamEmbedReason, launchDarklyParamStrong)
+                        if launchDarklyLocalAncestors.doesExist(prereqKey) then
+                          ' Cyclic edge: skip descent, continue with remaining prerequisites
+                          ' at this level. The requested flag's value and reason are unaffected.
+                        else
+                          m.variationDetail(prereqKey, invalid, launchDarklyParamEmbedReason, launchDarklyParamStrong, launchDarklyLocalAncestors)
+                        end if
                       End For
+                      launchDarklyLocalAncestors.delete(launchDarklyParamFlagKey)
                     end if
 
                     launchDarklyLocalDetails = {}

--- a/rawsrc/LaunchDarklyClient.brs
+++ b/rawsrc/LaunchDarklyClient.brs
@@ -83,16 +83,9 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                     m.private.handleEventsForEval(launchDarklyLocalState)
 
                     if launchDarklyLocalFlag.prerequisites <> invalid AND launchDarklyLocalFlag.prerequisites.count() > 0 then
-                      ' Recurse on prerequisites to emulate prereq evaluations occurring with
-                      ' desirable side effects such as events for prereqs.
-                      '
-                      ' launchDarklyParamVisited tracks the chain of prerequisite dependencies
-                      ' from the top-level evaluation to (but not including) the current flag.
-                      ' It is allocated lazily: variation calls on prereq-less flags allocate
-                      ' no associative array. Once created it is shared for the rest of the
-                      ' walk via add-before-recurse / delete-after-recurse. A prerequisite key
-                      ' already in the map closes a cycle; descent is skipped and the loop
-                      ' continues with the remaining prerequisites at the current level.
+                      ' Recurse on prerequisites to emit their evaluation events.
+                      ' launchDarklyParamVisited tracks the current path so a cyclic
+                      ' prerequisite graph terminates instead of recursing without bound.
                       launchDarklyLocalAncestors = launchDarklyParamVisited
                       if launchDarklyLocalAncestors = invalid then
                           launchDarklyLocalAncestors = {}
@@ -100,8 +93,7 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                       launchDarklyLocalAncestors[launchDarklyParamFlagKey] = true
                       For Each prereqKey in launchDarklyLocalFlag.prerequisites
                         if launchDarklyLocalAncestors.doesExist(prereqKey) then
-                          ' Cyclic edge: skip descent, continue with remaining prerequisites
-                          ' at this level. The requested flag's value and reason are unaffected.
+                          ' Cyclic edge: skip descent.
                         else
                           m.variationDetail(prereqKey, invalid, launchDarklyParamEmbedReason, launchDarklyParamStrong, launchDarklyLocalAncestors)
                         end if

--- a/rawsrc/LaunchDarklySG.brs
+++ b/rawsrc/LaunchDarklySG.brs
@@ -53,6 +53,7 @@ function LaunchDarklySG(launchDarklyParamClientNode as Dynamic) as Object
         end function
     }
 
+    launchDarklyLocalThis.private.append(LaunchDarklyClientSharedPrivateFunctions())
     launchDarklyLocalThis.append(LaunchDarklyClientSharedFunctions(launchDarklyParamClientNode))
 
     return launchDarklyLocalThis

--- a/src/contract-tests/components/HttpServerTask.brs
+++ b/src/contract-tests/components/HttpServerTask.brs
@@ -319,6 +319,7 @@ function Handler(clients as Object, launchDarklyNode as Object) as Object
               "inline-context-all",
               "anonymous-redaction",
               "client-prereq-events",
+              "client-prereq-cycle-detection",
               "polling-gzip",
             ]
 

--- a/src/test/source/tests/Test__Client.brs
+++ b/src/test/source/tests/Test__Client.brs
@@ -520,6 +520,129 @@ function TestCase__Client_AllFlags() as String
     return m.assertEqual(formatJSON(allFlagsState), formatJSON(expected))
 end function
 
+' Cycle-detection tests exercise the ancestor-set cycle guard added to variationDetail.
+' Each test constructs a cyclic prereq graph in the store, evaluates one flag on the cycle,
+' and asserts (a) the requested flag returns its cached value unchanged and (b) the recorded
+' feature events match exactly one entry per cycle-safe descent.
+
+function countFeatureEventsInOrder(events as Object) as Object
+    keys = createObject("roArray", 0, true)
+    for i = 0 to events.count() - 1
+        e = events[i]
+        if type(e) = "roAssociativeArray" and e.kind = "feature" then
+            keys.push(e.key)
+        end if
+    end for
+    return keys
+end function
+
+function TestCase__Client_CycleDetection_SelfLoop() as String
+    client = makeTestClientInitialized()
+    ' flagA's only prerequisite is itself; the cycle guard skips descent.
+    client.private.store.putAll({
+        flagA: {
+            value: "cached",
+            variation: 0,
+            version: 1,
+            trackEvents: true,
+            prerequisites: ["flagA"]
+        }
+    })
+
+    actualValue = client.variation("flagA", "default")
+    a = m.assertEqual(actualValue, "cached")
+    if a <> "" then
+        return a
+    end if
+
+    events = client.private.eventProcessor.flush()
+    featureKeys = countFeatureEventsInOrder(events)
+    ' Only flagA emits a feature event; the self-prereq is cycle-skipped.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA"]))
+end function
+
+function TestCase__Client_CycleDetection_TwoCycleEvaluatingA() as String
+    client = makeTestClientInitialized()
+    client.private.store.putAll({
+        flagA: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagB"]},
+        flagB: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagA"]}
+    })
+
+    actualValue = client.variation("flagA", "default")
+    a = m.assertEqual(actualValue, "cached")
+    if a <> "" then
+        return a
+    end if
+
+    events = client.private.eventProcessor.flush()
+    featureKeys = countFeatureEventsInOrder(events)
+    ' A -> B -> [A skipped]. Events deepest-first: B (as prereq of A), then A.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagB", "flagA"]))
+end function
+
+function TestCase__Client_CycleDetection_TwoCycleEvaluatingB() as String
+    client = makeTestClientInitialized()
+    client.private.store.putAll({
+        flagA: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagB"]},
+        flagB: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagA"]}
+    })
+
+    actualValue = client.variation("flagB", "default")
+    a = m.assertEqual(actualValue, "cached")
+    if a <> "" then
+        return a
+    end if
+
+    events = client.private.eventProcessor.flush()
+    featureKeys = countFeatureEventsInOrder(events)
+    ' Symmetric: same graph, entry from B. Events: A (as prereq of B), then B.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB"]))
+end function
+
+function TestCase__Client_CycleDetection_ThreeCycle() as String
+    client = makeTestClientInitialized()
+    client.private.store.putAll({
+        flagA: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagB"]},
+        flagB: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagC"]},
+        flagC: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagA"]}
+    })
+
+    actualValue = client.variation("flagA", "default")
+    a = m.assertEqual(actualValue, "cached")
+    if a <> "" then
+        return a
+    end if
+
+    events = client.private.eventProcessor.flush()
+    featureKeys = countFeatureEventsInOrder(events)
+    ' A -> B -> C -> [A skipped]. Events emitted deepest-first: C, B, A.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagC", "flagB", "flagA"]))
+end function
+
+function TestCase__Client_CycleDetection_Diamond() as String
+    ' Diamond: A -> [B, C], B -> [D], C -> [D]. Not a cycle. Ancestor-set (current-path)
+    ' semantics let D be reached on each of the two independent paths, so D emits twice.
+    ' A naive "visited across the whole walk" implementation would drop the second event.
+    client = makeTestClientInitialized()
+    client.private.store.putAll({
+        flagA: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagB", "flagC"]},
+        flagB: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagD"]},
+        flagC: {value: "cached", variation: 0, version: 1, trackEvents: true, prerequisites: ["flagD"]},
+        flagD: {value: "cached", variation: 0, version: 1, trackEvents: true}
+    })
+
+    actualValue = client.variation("flagA", "default")
+    a = m.assertEqual(actualValue, "cached")
+    if a <> "" then
+        return a
+    end if
+
+    events = client.private.eventProcessor.flush()
+    featureKeys = countFeatureEventsInOrder(events)
+    ' Events (deepest-first per path): D (via B), B, D (via C), C, A. D appears twice.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagD", "flagB", "flagD", "flagC", "flagA"]))
+end function
+
 function TestSuite__Client() as Object
     this = BaseTestSuite()
 
@@ -546,6 +669,11 @@ function TestSuite__Client() as Object
     this.addTest("TestCase__Client_VariationDetail_WrongType", TestCase__Client_VariationDetail_WrongType)
     this.addTest("TestCase__Client_VariationDetail_ClientNotReady", TestCase__Client_VariationDetail_ClientNotReady)
     this.addTest("TestCase__Client_AllFlags", TestCase__Client_AllFlags)
+    this.addTest("TestCase__Client_CycleDetection_SelfLoop", TestCase__Client_CycleDetection_SelfLoop)
+    this.addTest("TestCase__Client_CycleDetection_TwoCycleEvaluatingA", TestCase__Client_CycleDetection_TwoCycleEvaluatingA)
+    this.addTest("TestCase__Client_CycleDetection_TwoCycleEvaluatingB", TestCase__Client_CycleDetection_TwoCycleEvaluatingB)
+    this.addTest("TestCase__Client_CycleDetection_ThreeCycle", TestCase__Client_CycleDetection_ThreeCycle)
+    this.addTest("TestCase__Client_CycleDetection_Diamond", TestCase__Client_CycleDetection_Diamond)
 
     return this
 end function

--- a/src/test/source/tests/Test__Client.brs
+++ b/src/test/source/tests/Test__Client.brs
@@ -576,8 +576,10 @@ function TestCase__Client_CycleDetection_TwoCycleEvaluatingA() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' A -> B -> [A skipped]. Events deepest-first: B (as prereq of A), then A.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagB", "flagA"]))
+    ' Roku emits the current flag's event before recursing (parent-first), so events
+    ' are [A, B]. This diverges from other client SDKs, which emit deepest-first
+    ' ([B, A]); tracked in follow-up ticket to align.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB"]))
 end function
 
 function TestCase__Client_CycleDetection_TwoCycleEvaluatingB() as String
@@ -595,8 +597,8 @@ function TestCase__Client_CycleDetection_TwoCycleEvaluatingB() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' Symmetric: same graph, entry from B. Events: A (as prereq of B), then B.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB"]))
+    ' Symmetric: same graph, entry from B. Parent-first order (see companion test).
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagB", "flagA"]))
 end function
 
 function TestCase__Client_CycleDetection_ThreeCycle() as String
@@ -615,8 +617,8 @@ function TestCase__Client_CycleDetection_ThreeCycle() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' A -> B -> C -> [A skipped]. Events emitted deepest-first: C, B, A.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagC", "flagB", "flagA"]))
+    ' A -> B -> C -> [A skipped]. Parent-first ordering yields A, B, C.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB", "flagC"]))
 end function
 
 function TestCase__Client_CycleDetection_Diamond() as String
@@ -639,8 +641,10 @@ function TestCase__Client_CycleDetection_Diamond() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' Events (deepest-first per path): D (via B), B, D (via C), C, A. D appears twice.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagD", "flagB", "flagD", "flagC", "flagA"]))
+    ' Parent-first per path: A, then descend B (emit B, then D), then descend C
+    ' (emit C, then D). D emits twice, exercising the per-path (current-path)
+    ' ancestor-set semantics vs a global visited set.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB", "flagD", "flagC", "flagD"]))
 end function
 
 function TestSuite__Client() as Object


### PR DESCRIPTION
## Summary

Adds defensive cycle detection to the recursive prerequisite walk in `variationDetail` (`LaunchDarklyClient.brs`), bringing the Roku client SDK's behavior into line with the LaunchDarkly server SDK evaluators.

Tracker: [SDK-2710](https://launchdarkly.atlassian.net/browse/SDK-2710). Parent: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695). Spec change: [sdk-specs#246](https://github.com/launchdarkly/sdk-specs/pull/246) (CSPE 1.2.5, 1.2.5.1, 1.2.5.2). Contract-test coverage: [sdk-test-harness#384](https://github.com/launchdarkly/sdk-test-harness/pull/384) (merged in v2.38.0). Companion PRs: [android-client-sdk#377](https://github.com/launchdarkly/android-client-sdk/pull/377), [ios-client-sdk#512](https://github.com/launchdarkly/ios-client-sdk/pull/512), [js-core#1816](https://github.com/launchdarkly/js-core/pull/1816), [flutter-client-sdk#329](https://github.com/launchdarkly/flutter-client-sdk/pull/329), [dotnet-core#317](https://github.com/launchdarkly/dotnet-core/pull/317), [cpp-sdks#582](https://github.com/launchdarkly/cpp-sdks/pull/582).

## Background

The LaunchDarkly service validates prerequisite graphs on every mutation and rejects any change that would produce a cycle, so under normal operation the SDK does not see a cyclic prerequisite graph. Server-side SDK evaluators nonetheless carry defensive cycle detection for exceptional cases — for example, delivery of updates out of order or a persisted state loaded from disk that predates a subsequent correction. This PR extends the same defensive posture to the Roku client SDK.

## The fix

`variationDetail` now threads a lazily-allocated associative array through the recursion carrying the flag keys on the current evaluation path. Before descending into a prerequisite, the walker checks whether that key is already on the path; if so, it skips that edge and continues with remaining prerequisites at the same level.

- **Lazy allocation**: variation calls on prereq-less flags (the common case) allocate no associative array. The map is created only when the walker descends into a prerequisite for the first time in a call, then reused for the rest of the walk.
- **Mutable add/delete around the loop**: no per-descent copy. The current flag's key is inserted before the loop and removed after, so the invariant "the map contains exactly the current path" holds across sibling descents.
- **Ancestor-set (current-path) semantics** — this is deliberate. A prerequisite reached via multiple non-cyclic paths (a diamond `A -> [B, C], B -> [D], C -> [D]`) is not a cycle; each path should emit its own prerequisite event. A global visited-set would silently drop the second event; the ancestor-set pattern correctly emits D twice. There is a unit test guarding this.

The optional trailing parameter `launchDarklyParamVisited=invalid` is added to `variationDetail`, so existing callers (`boolVariation`, `intVariationDetail`, `stringVariationDetail`, `doubleVariationDetail`, `jsonVariationDetail`, and the untyped `variation`) work unchanged.

## Caller-visible behavior on a cycle

The requested flag returns its cached value and reason unchanged. A client-side prerequisite cycle is not surfaced as `MALFORMED_FLAG` and does not fall back to the caller-provided default value. This differs from server-side behavior — the client already holds an authoritative pre-evaluated result from the server; only the ancillary event walk is affected by the cycle.

## Files changed

- `rawsrc/LaunchDarklyClient.brs` — cycle guard in `variationDetail`.
- `src/test/source/tests/Test__Client.brs` — 5 new unit tests: self-loop, two-cycle (evaluating each end), three-cycle, and a non-cyclic diamond that asserts the shared descendant emits an event for each path (the ancestor-set regression fence).
- `src/contract-tests/components/HttpServerTask.brs` — declares `client-prereq-cycle-detection` so the matching contract tests in sdk-test-harness v2.38.0+ activate for this SDK.

## Verification

- **Unit tests**: 5 new `TestCase__Client_CycleDetection_*` cases follow the existing `TestCase__Client_*` pattern (seed `client.private.store`, call `client.variation()`, flush and inspect the event queue). Local execution requires a Roku device (`ukor test`); CI provides the actual test run.
- **Contract tests**: local run requires deployment to a Roku device; CI provides the run against the released harness. The new suite (`client-prereq-cycle-detection`) will activate as soon as CI picks up harness v2.38.0+.

## Changelog

> Updated prerequisite evaluation event emission to match server SDK behavior for cyclic prerequisite graphs.

[SDK-2710]: https://launchdarkly.atlassian.net/browse/SDK-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the prerequisite event-walk in core flag evaluation, but behavior for normal graphs is preserved and cycles only skip redundant descent; coverage is strong via new unit and contract capability tests.
> 
> **Overview**
> Adds **defensive cycle detection** when the Roku client walks flag **prerequisites** to emit evaluation events, matching other LaunchDarkly SDKs and avoiding unbounded recursion on malformed graphs.
> 
> Core `variationDetail` logic moves into **`LaunchDarklyClientSharedPrivateFunctions`** and is merged into both the standard client and SceneGraph client. The recursive walk threads a **current-path ancestor set** (`launchDarklyParamVisited`): before descending into a prerequisite, if that flag is already on the path the edge is skipped; diamonds still emit events per path (not a global visited set). **Public variation APIs are unchanged**—they delegate to the private implementation with `m.status`.
> 
> Contract tests advertise capability **`client-prereq-cycle-detection`**. **Five unit tests** cover self-loop, 2- and 3-cycles, and a diamond graph (cached values unchanged; feature event order asserted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e595283b4ed96e646921ffaf290fa0cd93ca751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->