### PR TITLE
fix: emit prerequisite events deepest-first

### DIFF
--- a/rawsrc/LaunchDarklyClient.brs
+++ b/rawsrc/LaunchDarklyClient.brs
@@ -80,8 +80,6 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                         launchDarklyLocalState.reason = LaunchDarklyUtility().deepCopy(launchDarklyLocalReason)
                     end if
 
-                    m.private.handleEventsForEval(launchDarklyLocalState)
-
                     if launchDarklyLocalFlag.prerequisites <> invalid AND launchDarklyLocalFlag.prerequisites.count() > 0 then
                       ' Recurse on prerequisites to emit their evaluation events.
                       ' launchDarklyParamVisited tracks the current path so a cyclic
@@ -100,6 +98,8 @@ function LaunchDarklyClientSharedFunctions(launchDarklyParamSceneGraphNode as Ob
                       End For
                       launchDarklyLocalAncestors.delete(launchDarklyParamFlagKey)
                     end if
+
+                    m.private.handleEventsForEval(launchDarklyLocalState)
 
                     launchDarklyLocalDetails = {}
                     launchDarklyLocalDetails["result"] = launchDarklyLocalValue

--- a/src/test/source/tests/Test__Client.brs
+++ b/src/test/source/tests/Test__Client.brs
@@ -576,10 +576,8 @@ function TestCase__Client_CycleDetection_TwoCycleEvaluatingA() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' Roku emits the current flag's event before recursing (parent-first), so events
-    ' are [A, B]. This diverges from other client SDKs, which emit deepest-first
-    ' ([B, A]); tracked in follow-up ticket to align.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB"]))
+    ' A -> B -> [A skipped]. Events deepest-first: B (as prereq of A), then A.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagB", "flagA"]))
 end function
 
 function TestCase__Client_CycleDetection_TwoCycleEvaluatingB() as String
@@ -597,8 +595,8 @@ function TestCase__Client_CycleDetection_TwoCycleEvaluatingB() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' Symmetric: same graph, entry from B. Parent-first order (see companion test).
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagB", "flagA"]))
+    ' Symmetric: same graph, entry from B. Events: A (as prereq of B), then B.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB"]))
 end function
 
 function TestCase__Client_CycleDetection_ThreeCycle() as String
@@ -617,8 +615,8 @@ function TestCase__Client_CycleDetection_ThreeCycle() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' A -> B -> C -> [A skipped]. Parent-first ordering yields A, B, C.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB", "flagC"]))
+    ' A -> B -> C -> [A skipped]. Events emitted deepest-first: C, B, A.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagC", "flagB", "flagA"]))
 end function
 
 function TestCase__Client_CycleDetection_Diamond() as String
@@ -641,10 +639,8 @@ function TestCase__Client_CycleDetection_Diamond() as String
 
     events = client.private.eventProcessor.flush()
     featureKeys = countFeatureEventsInOrder(events)
-    ' Parent-first per path: A, then descend B (emit B, then D), then descend C
-    ' (emit C, then D). D emits twice, exercising the per-path (current-path)
-    ' ancestor-set semantics vs a global visited set.
-    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagA", "flagB", "flagD", "flagC", "flagD"]))
+    ' Events (deepest-first per path): D (via B), B, D (via C), C, A. D appears twice.
+    return m.assertEqual(FormatJSON(featureKeys), FormatJSON(["flagD", "flagB", "flagD", "flagC", "flagA"]))
 end function
 
 function TestSuite__Client() as Object


### PR DESCRIPTION
## Summary

Aligns Roku's prerequisite event emission order with the rest of the LaunchDarkly SDK family. `variationDetail` in `LaunchDarklyClient.brs` now emits the current flag's feature event **after** the recursive prerequisite walk instead of before it. For a flag `A` with prerequisite `B`, events now land as `[B, A]` (matching every other client and server SDK) rather than `[A, B]`.

Tracker: [SDK-2745](https://launchdarkly.atlassian.net/browse/SDK-2745). Stacked on [#54](https://github.com/launchdarkly/roku-client-sdk/pull/54).

## Motivation

A survey during the cycle-detection work in #54 found that Roku was the only outlier across all client SDKs (.NET, JS, Flutter, Android, iOS, C++) and every server SDK (Go, .NET, JS, Java, Python, Ruby, C++) — all of which emit prerequisite events before the parent's event. LaunchDarkly's event ingestion does not depend on intra-batch ordering, so the pre-existing behavior wasn't a functional bug, but the divergence is a cross-SDK anomaly worth correcting.

## Changes

- `rawsrc/LaunchDarklyClient.brs`: move the `handleEventsForEval(launchDarklyLocalState)` call to after the prerequisite recursion block.
- `src/test/source/tests/Test__Client.brs`: update the four cycle-detection tests to expect deepest-first ordering (e.g., `[flagB, flagA]` for a two-cycle evaluating A).

## Test plan

- [x] Unit tests pass on a Roku Express device (all `TestSuite__Client` cases, including the five `CycleDetection_*` tests).
- [x] SDK contract tests pass against the harness: 784 total, 30 skipped, 754 ran, all passed. This includes every `events/summary events/prerequisites/handles cycles/*` and `events/prerequisite events handle cycles/*` case.
- [x] Ordering change is confirmed on device: two-cycle now emits `[B, A]`.

[SDK-2745]: https://launchdarkly.atlassian.net/browse/SDK-2745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single reorder of event emission in `variationDetail`; flag evaluation and cycle detection are untouched, and ingestion does not rely on intra-batch event order.
> 
> **Overview**
> **`variationDetail`** in `LaunchDarklyClient.brs` now calls **`handleEventsForEval`** *after* walking prerequisites instead of before. Prerequisite feature events are emitted **deepest-first** (e.g. `B` then `A` when `A` depends on `B`), matching other LaunchDarkly client and server SDKs; Roku had been parent-first.
> 
> The four **`CycleDetection_*`** tests in `Test__Client.brs` were updated to assert the new event key order for two-cycles, three-cycles, and the diamond graph (including duplicate `D` events on separate paths). Evaluation values and cycle-guard behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de34ff3051bd2e245be3ad2f2388b0fec1f4dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->